### PR TITLE
Review#1

### DIFF
--- a/model/menuModel.go
+++ b/model/menuModel.go
@@ -130,6 +130,9 @@ func (p *Model) SortMenu() []interface{} {
 		array = append(array, []interface{}{p.GetReviewWithMenu(menu.Name).Grade, menu.Name})
 	}
 	sort.Slice(array, func(i, j int) bool {
+		//Grade의 type이 int64이므로 type assertion을 통해 값에 접근할 때는
+		//int가 아닌 int64로 변경해주어야 합니다. 
+		//그렇지 않으면 firstElementI와 firstElementJ는 int의 zero value가 출력됩니다.
 		firstElementI, _ := array[i].([]interface{})[0].(int)
 		firstElementJ, _ := array[j].([]interface{})[0].(int)
 		return firstElementI > firstElementJ


### PR DESCRIPTION
Go에서는 Type assertion과 Type conversion이 존재합니다.
Type conversion은 우리가 흔히 알고 있는 명시적 형변환을 의미하며, 아래와 같이 사용합니다.
```
var n1 int = 1
var n2 int64 = int64(n1)
```
그리고 Type assertion은 Interface가 가지고 있는 값에 접근할 수 있게 해주며 kjh24871 님이 작성하신 방법을 사용합니다.
간단히 나타내자면 아래와 같은 모습이 되겠네요. 
```
var v interface{} = 1
n := v.(int)
```
comment가 작성된 부분은 Menu model의 SortMenu()로, 각 메뉴를 평점을 기준으로 sort하는 것으로 보입니다.
현재는 평점을 나타내는 Grade의 type은 int64인데, int로 access하고 있으므로 int의 zero value인 0이 firstElementI, firstElementJ에 각각 할당될 것입니다. 
만약 underbar 로 작성하신 부분의 값을 출력해본다면 false 값을 출력하게 되겠군요.
코드가 의도한 대로 동작되게 하려면 이 부분을 수정하시면 될 것 같습니다.

reference: https://go.dev/tour/methods/15